### PR TITLE
Fix for special characters in command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 const crypto = require('crypto')
 const querystring = require('querystring')
 
+// Adhering to RFC 3986
+// Inspired from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+function fixedEncodeURIComponent (str) {
+  return str.replace(/[!'()*]/g, function (c) {
+    return '%' + c.charCodeAt(0).toString(16)
+  })
+}
+
 /**
  * Validate incoming Slack request
  *
@@ -20,7 +28,7 @@ function validateSlackRequest (slackAppSigningSecret, httpReq, logging) {
   }
   const xSlackRequestTimeStamp = httpReq.get('X-Slack-Request-Timestamp')
   const SlackSignature = httpReq.get('X-Slack-Signature')
-  const bodyPayload = querystring.stringify(httpReq.body).replace(/%20/g, '+') // Fix for #1
+  const bodyPayload = fixedEncodeURIComponent(querystring.stringify(httpReq.body).replace(/%20/g, '+')) // Fix for #1
   if (!(xSlackRequestTimeStamp && SlackSignature && bodyPayload)) {
     if (logging) { console.log('Missing part in Slack\'s request') }
     return false

--- a/test/validate-slack-request.js
+++ b/test/validate-slack-request.js
@@ -44,6 +44,14 @@ describe('Slack incoming request test', function () {
     })
   })
 
+  describe('Test special characters in command', function() {
+    it('should return true', function() {
+      testHttpRequest = getTestHttpRequest('(!)')
+      testHttpRequest['X-Slack-Signature'] = 'v0=85b7bd32a59380ae4a50db6d76eed906f36daec1660ceced4907f44eaaf60757'
+      assert.equal(slackValidateRequest('slackSigningSecret', testHttpRequest), true)
+    })
+  })
+
   describe('Wrong signature', function () {
     it('should return false if the signature doesn\'t match', function () {
       testHttpRequest = getTestHttpRequest()
@@ -105,5 +113,4 @@ describe('Slack incoming request test', function () {
       assert.throws(() => { slackValidateRequest(slackSigningSecret, testHttpRequest, 1) })
     })
   })
-
 })


### PR DESCRIPTION
The querystring.stringify() do not encode some special characters, namely: !, ', (, ), and *. More info [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent).
 
A new function added to encode this characters. 

Fix #3 